### PR TITLE
Update docker-compose.yml

### DIFF
--- a/nifi/docker-compose.yml
+++ b/nifi/docker-compose.yml
@@ -169,6 +169,9 @@ services:
       #INITIAL_ADMIN_IDENTITY: 'CN=Random User, O=Apache, OU=NiFi, C=US'
       
       #NODE_IDENTITY: ''
+      
+      #getting nifi.sensitive.props.key not found error without this prop
+      #NIFI_SENSITIVE_PROPS_KEY:please_edit_me!
 
 
 


### PR DESCRIPTION
 Getting nifi.sensitive.props.key not found error without this prop in docker 1.14.0 image.